### PR TITLE
Update dependency blobs for v9.3.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,15 +1,20 @@
 nginx/nginx-1.28.3.tar.gz:
   size: 1284562
+  object_id: eaa4be66-50a8-43e7-577c-f39659cc76f9
   sha: sha256:2c96a946bfb0882a21744ed429770a2123ae1828c7c48665092993ddee91a918
 nginx/pcre2-10.47.tar.gz:
   size: 2792969
+  object_id: b3cee622-12df-462a-5b47-ec2e12682967
   sha: sha256:c08ae2388ef333e8403e670ad70c0a11f1eed021fd88308d7e02f596fcd9dc16
 shield/shield-server-linux-amd64.tar.gz:
   size: 150938797
+  object_id: 74cab4ce-f556-42ee-7619-98cd0dab41a1
   sha: sha256:e220ad7670500238f4e7bdb9482d05ce0bc55f4d1698e2f56f3f959f60356faf
 sqlite3/sqlite-autoconf-3470200.tar.gz:
   size: 3328600
+  object_id: 1ce50eac-5ac0-47bc-4c42-501f5efcfa50
   sha: sha256:f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
 vault/vault_1.20.4_linux_amd64.zip:
   size: 174116347
+  object_id: eeb166d5-7b3c-4bb3-6c81-8e0ab9216b2d
   sha: sha256:fc5fb5d01d192f1216b139fb5c6af17e3af742aaeffc289fd861920ec55f2c9c

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,11 +1,9 @@
-nginx/nginx-1.26.3.tar.gz:
-  size: 1260179
-  object_id: f9e78d87-ec64-4553-574c-0c06950cff12
-  sha: sha256:69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa
-nginx/pcre2-10.44.tar.gz:
-  size: 2552792
-  object_id: 92e967c3-b43d-42f8-6154-9cbc3cb18c37
-  sha: sha256:86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b
+nginx/nginx-1.28.3.tar.gz:
+  size: 1284562
+  sha: sha256:2c96a946bfb0882a21744ed429770a2123ae1828c7c48665092993ddee91a918
+nginx/pcre2-10.47.tar.gz:
+  size: 2792969
+  sha: sha256:c08ae2388ef333e8403e670ad70c0a11f1eed021fd88308d7e02f596fcd9dc16
 shield/shield-server-linux-amd64.tar.gz:
   size: 143834961
   object_id: 91576a90-49c0-47cd-4dc8-bf6c3ec753fd

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -11,7 +11,6 @@ shield/shield-server-linux-amd64.tar.gz:
 sqlite3/sqlite-autoconf-3470200.tar.gz:
   size: 3328600
   sha: sha256:f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
-vault/vault_1.17.6_linux_amd64.zip:
-  size: 148610681
-  object_id: 73151c05-c515-48ce-6f8b-d3f3626632cb
-  sha: sha256:0cddc1fbbb88583b5ba5b845f9f8fae47c6fb39a6d48cd543c6ba6fd3ac1a669
+vault/vault_1.20.4_linux_amd64.zip:
+  size: 174116347
+  sha: sha256:fc5fb5d01d192f1216b139fb5c6af17e3af742aaeffc289fd861920ec55f2c9c

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -5,9 +5,8 @@ nginx/pcre2-10.47.tar.gz:
   size: 2792969
   sha: sha256:c08ae2388ef333e8403e670ad70c0a11f1eed021fd88308d7e02f596fcd9dc16
 shield/shield-server-linux-amd64.tar.gz:
-  size: 143834961
-  object_id: 91576a90-49c0-47cd-4dc8-bf6c3ec753fd
-  sha: sha256:c736df698661335352dbdfaee234bccf32bfa403479fb107f5b2b269c94e063d
+  size: 150938797
+  sha: sha256:e220ad7670500238f4e7bdb9482d05ce0bc55f4d1698e2f56f3f959f60356faf
 sqlite3/sqlite-autoconf-3470200.tar.gz:
   size: 3328600
   sha: sha256:f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -8,10 +8,9 @@ shield/shield-server-linux-amd64.tar.gz:
   size: 143834961
   object_id: 91576a90-49c0-47cd-4dc8-bf6c3ec753fd
   sha: sha256:c736df698661335352dbdfaee234bccf32bfa403479fb107f5b2b269c94e063d
-sqlite3/sqlite-autoconf-3460000.tar.gz:
-  size: 3265248
-  object_id: 1af3de5f-1631-49a5-490d-67249c4cfadf
-  sha: sha256:6f8e6a7b335273748816f9b3b62bbdc372a889de8782d7f048c653a447417a7d
+sqlite3/sqlite-autoconf-3470200.tar.gz:
+  size: 3328600
+  sha: sha256:f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
 vault/vault_1.17.6_linux_amd64.zip:
   size: 148610681
   object_id: 73151c05-c515-48ce-6f8b-d3f3626632cb

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -2,12 +2,12 @@
 set -eux
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
-tar -xzf "nginx/pcre2-10.44.tar.gz"
-tar -xzf "nginx/nginx-1.26.3.tar.gz"
-pushd nginx-1.26.3
+tar -xzf "nginx/pcre2-10.47.tar.gz"
+tar -xzf "nginx/nginx-1.28.3.tar.gz"
+pushd nginx-1.28.3
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
-    --with-pcre=../pcre2-10.44 \
+    --with-pcre=../pcre2-10.47 \
     --with-http_stub_status_module \
     --with-http_ssl_module \
     --with-http_dav_module

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -1,5 +1,5 @@
 ---
 name: nginx
 files:
-  - nginx/nginx-1.26.3.tar.gz
-  - nginx/pcre2-10.44.tar.gz
+  - nginx/nginx-1.28.3.tar.gz
+  - nginx/pcre2-10.47.tar.gz

--- a/packages/sqlite3/packaging
+++ b/packages/sqlite3/packaging
@@ -2,8 +2,8 @@
 set -eux
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
-tar -xzvf sqlite3/sqlite-autoconf-3460000.tar.gz
-pushd sqlite-autoconf-3460000
+tar -xzvf sqlite3/sqlite-autoconf-3470200.tar.gz
+pushd sqlite-autoconf-3470200
   ./configure --prefix ${BOSH_INSTALL_TARGET}
   make -j$CPUS
   make install

--- a/packages/sqlite3/spec
+++ b/packages/sqlite3/spec
@@ -1,4 +1,4 @@
 ---
 name: sqlite3
 files:
-  - sqlite3/sqlite-autoconf-3460000.tar.gz
+  - sqlite3/sqlite-autoconf-3470200.tar.gz

--- a/packages/vault/packaging
+++ b/packages/vault/packaging
@@ -4,6 +4,6 @@ set -eux
 mkdir $BOSH_INSTALL_TARGET/bin
 
 pushd vault
-  unzip vault_1.17.6_linux_amd64.zip
+  unzip vault_1.20.4_linux_amd64.zip
   cp -a vault $BOSH_INSTALL_TARGET/bin
 popd

--- a/packages/vault/spec
+++ b/packages/vault/spec
@@ -1,4 +1,4 @@
 ---
 name: vault
 files:
-- vault/vault_1.20.4_linux_amd64.zip
+  - vault/vault_1.20.4_linux_amd64.zip

--- a/packages/vault/spec
+++ b/packages/vault/spec
@@ -1,4 +1,4 @@
 ---
 name: vault
 files:
-- vault/vault_1.17.6_linux_amd64.zip
+- vault/vault_1.20.4_linux_amd64.zip


### PR DESCRIPTION
## Summary

- Update nginx 1.26.3 → 1.28.3 and paired pcre2 10.44 → 10.47
- Update sqlite3 3.46.0 → 3.47.2
- Update vault 1.17.6 → 1.20.4
- Update shield-server v9.0.0-2-ged150ba5 → v9.0.1

## Test plan

- [x] `bosh create-release --force` succeeds locally with all five blobs incorporated